### PR TITLE
fixed missing port issue on /embedded

### DIFF
--- a/app/assets/javascripts/embedded.js.coffee
+++ b/app/assets/javascripts/embedded.js.coffee
@@ -6,6 +6,9 @@ update_code= (item, user_group_id) ->
   if $("#embedded_#{item}_url").length>0 && $("#embedded_#{item}_iframe").length>0
     final_url = $("#embedded_#{item}_url").val()+'?user_group_id='+user_group_id
 
+    if window.location.port && final_url.indexOf(window.location.host) == -1
+        final_url = final_url.replace "//#{window.location.hostname}/", "//#{window.location.host}/"
+
     width = $("#embedded_width").val()
     height = $("#embedded_height").val()
 


### PR DESCRIPTION
The issue is only relevant in rather special environments. In particular when the app is accessed through port-forwarding like it is set up by the [Dresden-Weekly ansible-rails-example](https://github.com/dresden-weekly/ansible-rails-example).

Instead of pointing to http://127.0.0.1:8081/embedded/... all urls for the iframes have just 127.0.0.1 without port as host part which looks slightly unpleasant.

Andreas encouraged me to make this PR and I will not be disappointed if it will not be accepted.